### PR TITLE
fix: Player* and Board* memory leaks

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8,23 +8,12 @@
 #include "game.hpp"
 #include <iostream>
 
-Game::Game()
+Game::Game() : player1(Player('X')), player2(Player('O')), board(new Board(7, 7))
 {
-    player1 = new Player('X');
-    player2 = new Player('O');
-    turn = player1;
+    turn = &player1;
     winner = NULL;
-    
-    board = new Board(7, 7);
+
     board -> initSlots();
-    
-//no idea why this doesn't work, or why i had to make pointers to instances:
-//    Player player1('X');
-//    Player player2('O');
-//    Player& turn = player1;
-    
-//    Board board(7, 7);
-//    board.initSlots();
 }
 
 bool Game::isRunning()
@@ -32,7 +21,7 @@ bool Game::isRunning()
     return running;
 }
 
-bool Game::win(Player* potentialWinner)
+bool Game::win(Player *potentialWinner)
 {
     int length = sizeof(winningNumbers) / sizeof(int);
     
@@ -57,12 +46,12 @@ void Game::gameOver()
 
 Player* Game::changeTurn()
 {
-    if (turn == player1)
+    if (turn == &player1)
     {
-        return player2;
+        return &player2;
     }
     
-    return player1;
+    return &player1;
 }
 
 

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -13,17 +13,19 @@
 #include "player.hpp"
 #include "slot.hpp"
 
+#include <memory>
+
 class Game {
     private:
         bool running = true;
     
         int winningNumbers[8] = {30, 238, 506, 627, 935, 1001, 1495, 7429};
-        Player* player1;
-        Player* player2;
-        Player* turn;
-        Player* winner;
+        Player player1;
+        Player player2;
+        Player *turn;
+        Player *winner;
     
-        Board* board;
+        std::unique_ptr<Board> board;
     
         std::string gameState = "start";
     
@@ -34,7 +36,7 @@ class Game {
         Player* changeTurn();
         bool isRunning();
         void gameOver();
-        bool win(Player* potentialWinner);
+        bool win(Player *player);
     
         void run();
     


### PR DESCRIPTION
Using raw pointers (i.e. player = new Player('X')) is a bad practice, bc you have to call `delete player` for each `new` you have called (you could do it with destructors, but as always with C++, you shall discover 100+ ways of shooting yourself in a foot).

So, I highly reccomend you checking 'smart pointers' (aka unique_ptr, shared_ptr), which could save you a lot of mental overhead. Using raw pointers in game-dev is fine, but you should be actually shure there'll be no leaks.

// Not gonna lie, I was bored at my job, when I found your channel. I wish you the best of luck.
